### PR TITLE
common: Fix build error on macOS Ventura with XCODE 14

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -20,7 +20,7 @@ libcommon_a_SOURCES = \
 	tmap.c \
 	tmap.h
 
-libcommon_a_LIBADD = \
+libcommon_la_LIBADD = \
 	../lib/libgnu.a
 
 AM_CPPFLAGS = \


### PR DESCRIPTION
Fixes:
2023-04-18T16:36:52.8543510Z ld: in ../common/libcommon.a(libgnu.a), archive member 'libgnu.a' with length 48528 is not mach-o or llvm bitcode file '../common/libcommon.a' for architecture x86_64

This is because macOS ld does not like having  an .a archive in another .a archive. One solution we found was to replace libcommon_a_LIBADD  by libcommon_la_LIBADD :_a_LIBADD runs ar, which is stupid and will add the .a file to the other .a library. _la_LIBADD runs libtool, which knows how to unpack the static archive before adding the objects.